### PR TITLE
final round logic added

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -35,10 +35,13 @@ function App() {
   const [roundTimer, setRoundTimer] = useState(-1)
   const [maxBet, setMaxBet] = useState(0);
   const [questionCounter, setQuestionCounter] = useState(0)
-  const roundLength = 180;
+  const roundLength = 10;
 
   const setEndView = useCallback(() => {
     if (bank > 0) {
+      setRound(3)
+      setColumn(0)
+      setRow(4)
       setView("finalRound")
     }
     else {
@@ -51,7 +54,7 @@ function App() {
       setDailyDouble([[Math.floor(Math.random() * 6), Math.floor(Math.random() * 5)], [Math.floor(Math.random() * 6), Math.floor(Math.random() * 5)]])
       setView("secondRound")
       setRoundTimer(roundLength)//time second round
-      setRound(round + 1)
+      setRound(2)
       setQuestionCounter(0)
       setHistory([
         [true, true, true, true, true],
@@ -122,6 +125,7 @@ function App() {
     }
     getWrongAnswers();
     setRound(1)
+    setBank(0)
     setHistory([
       [true, true, true, true, true],
       [true, true, true, true, true],
@@ -142,22 +146,30 @@ function App() {
 
   const correctAnswer = () => {
     document.getElementById("correct-sound").play();
-    setView('grid')
     setQuestionCounter(questionCounter + 1)
     setTimeout(() => {
       setBank(bank + questionValue);
     }, 500);
     reduceWrongAnswers()
+    if (round===3){
+      setView('win')
+    }else{
+      setView('grid')
+    }
   };
 
   const wrongAnswer = () => {
     document.getElementById("wrong-sound").play();
-    setView('grid')
     setQuestionCounter(questionCounter+1)
     setTimeout(() => {
       setBank(bank - questionValue);
     }, 500);
     reduceWrongAnswers()
+    if (round === 3) {
+      setView('win')
+    } else {
+      setView('grid')
+    }
   };
 
   const reduceWrongAnswers = () =>{
@@ -195,20 +207,23 @@ function App() {
       />
     )}
     if (view==='dailyDouble') return (
-      <AnnouncementPage text="Daily Double!" setView={setView} next='wager'/>
+      <AnnouncementPage text="Daily Double!" setView={setView} next='wager' time={2}/>
     )
     if (view === 'secondRound') return (
-      <AnnouncementPage text="Double Jeopardy!" setView={setView} next='grid' />
+      <AnnouncementPage text="Double Jeopardy!" setView={setView} next='grid' time={2} />
     )
     if (view === 'finalRound') return (
-      <AnnouncementPage text="Final Jeopardy" setView={setView} next='wager' time={3} />
+      <AnnouncementPage text="Final Jeopardy" setView={setView} next='finalRoundCategory' time={2} />
+    )
+    if (view === 'finalRoundCategory') return (
+      <AnnouncementPage text={`Category: ${board[2][0].title}`} setView={setView} next='wager' time={3} />
     )
     if (view === 'wager') return (
       <>
         <WagerScreen bank={bank} setBank={setBank} round={round} maxBet={maxBet && maxBet} setQuestionValue={setQuestionValue} setView={setView} />
       </>
     )
-    if(view ==="gameOver")return (
+    if(view ==="gameOver") return (
       <>
         <EndGame mode="fail" setView={setView} reset={reset}/>
       </>

--- a/src/components/WagerBar.jsx
+++ b/src/components/WagerBar.jsx
@@ -12,7 +12,7 @@ ValueLabelComponent.propTypes = {
 };
 
 function ValueLabelComponent(props) {
-    
+
     return (
         // <Tooltip open={open} enterTouchDelay={0} placement="top" title={value}>
         //     {children}
@@ -56,7 +56,6 @@ export default function CustomizedSlider(props) {
     const { betValue, setBetValue, percentage, setPercentage, maxBet } = props
 
     const sliderUpdate = (value) => {
-        console.log(value)
         setPercentage(value)
         console.log(Math.ceil((maxBet / 100) * value))
         setBetValue(Math.ceil((maxBet / 100) * value))

--- a/src/components/announcementPage.js
+++ b/src/components/announcementPage.js
@@ -28,8 +28,10 @@ const useStyles = makeStyles(theme => ({
 export default function AnnouncementPage(props) {
 
   const {setView, text, next, time} = props
-  const [timer, setTimer] = React.useState(time !==undefined ? time : 1)
+  const [timer, setTimer] = React.useState(time)
   const classes = useStyles();
+
+
 
   React.useEffect(() => {
     const counter = setInterval(() => countdown(), 1000);
@@ -42,6 +44,10 @@ export default function AnnouncementPage(props) {
     }
     setTimer(timer - 1)
   }
+
+  React.useEffect(() => {
+    setTimer(time)
+  }, [time]);
 
   return (
     <Box className={classes.main} >

--- a/src/components/questionCard.js
+++ b/src/components/questionCard.js
@@ -3,7 +3,7 @@ import React from "react";
 import { Box } from "@material-ui/core";
 import { makeStyles } from "@material-ui/core/styles";
 import Button from "@material-ui/core/Button";
-import Counter from "./Counter";
+//import Counter from "./Counter";
 import styled from "styled-components";
 
 const useStyles = makeStyles((theme) => ({
@@ -46,13 +46,13 @@ const useStyles = makeStyles((theme) => ({
 
 //Styling Counter bar
 
-const CounterBarContainer = styled.div`
-  width: 100vw;
-  margin: 0 auto;
-`;
+// const CounterBarContainer = styled.div`
+//   width: 100vw;
+//   margin: 0 auto;
+// `;
 
 const QuestionCard = (props) => {
-  const { clue, setView, correctAnswer, wrongAnswer, randomAnswers, shuffleArray } = props;
+  const { clue, correctAnswer, wrongAnswer, randomAnswers, shuffleArray } = props;
 
   const classes = useStyles();
 
@@ -78,11 +78,11 @@ const QuestionCard = (props) => {
 
   return (
     <Box className={classes.main}>
-      <Box className={classes.countdown}>
+      {/* <Box className={classes.countdown}>
         <CounterBarContainer>
-          <Counter setView={setView} wrongAnswer={wrongAnswer}/>
+          <Counter wrongAnswer={wrongAnswer}/>
         </CounterBarContainer>
-      </Box>
+      </Box> */}
       <Box className={`${classes.question}`}>
         <h1>{clue.question}</h1>
       </Box>

--- a/src/components/questionCard.js
+++ b/src/components/questionCard.js
@@ -4,7 +4,7 @@ import { Box } from "@material-ui/core";
 import { makeStyles } from "@material-ui/core/styles";
 import Button from "@material-ui/core/Button";
 //import Counter from "./Counter";
-import styled from "styled-components";
+//import styled from "styled-components";
 
 const useStyles = makeStyles((theme) => ({
   main: {


### PR DESCRIPTION
third round, final jeopardy
On round three, when something is answered after final jeopardy, switch view to win
if round 2 ends and bank is <=0, switch view to gameOver
the reset() function for new game isn't perfect. Will not create new board. (wrong answers too? maybe)
counter is removed until it is functional